### PR TITLE
Fix release workflow and unit tests

### DIFF
--- a/.github/workflows/tf_provider_release.yaml
+++ b/.github/workflows/tf_provider_release.yaml
@@ -24,15 +24,17 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
-        id: import_gpg
-        with:
-          gpg_private_key: ${{ secrets.terraform_gpg_private_key }}
-          passphrase: ${{ secrets.terraform_gpg_passphrase }}
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.terraform_gpg_private_key }}
+          GPG_PASSPHRASE: ${{ secrets.terraform_gpg_passphrase }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          GPG_FINGERPRINT=$(gpg --list-secret-keys --keyid-format long | grep sec | head -1 | awk '{print $2}' | cut -d'/' -f2)
+          echo "GPG_FINGERPRINT=$GPG_FINGERPRINT" >> "$GITHUB_ENV"
+      - name: Install GoReleaser
+        run: go install github.com/goreleaser/goreleaser/v2@latest
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
-        with:
-          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_FINGERPRINT: ${{ env.GPG_FINGERPRINT }}
+        run: goreleaser release --clean


### PR DESCRIPTION
## Summary
- Replace third-party actions (`crazy-max/ghaction-import-gpg`, `goreleaser/goreleaser-action`) with bash equivalents in the release workflow, since the org restricts actions to GitHub-owned and `hashicorp/*` only
- Add missing `test_helpers_test.go` to fix unit test compilation
- README and documentation updates

## Test plan
- [ ] Verify unit tests pass in CI
- [ ] After merge, delete and re-create `v0.3.3` tag on new main HEAD
- [ ] Verify release workflow completes successfully