### PR TITLE
Fix policy groups import test failure on modify_time

### DIFF
--- a/internal/provider/npapolicygroups_resource_test.go
+++ b/internal/provider/npapolicygroups_resource_test.go
@@ -32,7 +32,7 @@ func TestAccNPAPolicyGroups_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"group_order"},
+				ImportStateVerifyIgnore: []string{"group_order", "modify_time"},
 			},
 		},
 	})
@@ -87,7 +87,7 @@ func TestAccNPAPolicyGroups_import(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"group_order"},
+				ImportStateVerifyIgnore: []string{"group_order", "modify_time"},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- Add `modify_time` to `ImportStateVerifyIgnore` in policy groups import tests
- POST returns microsecond precision while GET truncates it, causing `ImportStateVerify` to fail

## Test plan
- [x] Full acceptance test suite passes (90 passed, 3 skipped, 0 failures)