### PR TITLE
Skip destination profile and IPS tests pending tenant license

### DIFF
--- a/internal/provider/destinationprofile_resource_test.go
+++ b/internal/provider/destinationprofile_resource_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccDestinationProfile_basic(t *testing.T) {
+	t.Skip("Skipping: Destination profiles require a license not enabled on the CI tenant")
+
 	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
 	resourceName := "netskope_destination_profile.test"
 	vars := config.Variables{
@@ -47,6 +49,8 @@ func TestAccDestinationProfile_basic(t *testing.T) {
 }
 
 func TestAccDestinationProfile_update(t *testing.T) {
+	t.Skip("Skipping: Destination profiles require a license not enabled on the CI tenant")
+
 	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
 	rNameUpdated := fmt.Sprintf("%s-updated", rName)
 	resourceName := "netskope_destination_profile.test"
@@ -85,6 +89,8 @@ func TestAccDestinationProfile_update(t *testing.T) {
 }
 
 func TestAccDestinationProfileDataSource_basic(t *testing.T) {
+	t.Skip("Skipping: Destination profiles require a license not enabled on the CI tenant")
+
 	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
 	dataSourceName := "data.netskope_destination_profile.test"
 	vars := config.Variables{
@@ -110,6 +116,8 @@ func TestAccDestinationProfileDataSource_basic(t *testing.T) {
 }
 
 func TestAccDestinationProfileListDataSource_basic(t *testing.T) {
+	t.Skip("Skipping: Destination profiles require a license not enabled on the CI tenant")
+
 	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
 	dataSourceName := "data.netskope_destination_profile_list.test"
 	vars := config.Variables{

--- a/internal/provider/drift_detection_test.go
+++ b/internal/provider/drift_detection_test.go
@@ -1424,6 +1424,8 @@ resource "netskope_gre_tunnel" "test" {
 // TestAccDrift_DestinationProfile verifies no drift on destination profile
 // resources with values list and optional description.
 func TestAccDrift_DestinationProfile(t *testing.T) {
+	t.Skip("Skipping: Destination profiles require a license not enabled on the CI tenant")
+
 	rName := fmt.Sprintf("%s-%s", testAccResourcePrefix, acctest.RandString(8))
 
 	resource.Test(t, resource.TestCase{
@@ -1453,6 +1455,8 @@ func TestAccDrift_DestinationProfile(t *testing.T) {
 // TestAccDrift_DestinationProfile_Minimal verifies no drift when only required
 // fields (name, type) are set and optional Computed fields are omitted.
 func TestAccDrift_DestinationProfile_Minimal(t *testing.T) {
+	t.Skip("Skipping: Destination profiles require a license not enabled on the CI tenant")
+
 	rName := fmt.Sprintf("%s-%s", testAccResourcePrefix, acctest.RandString(8))
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/ipsstatus_data_source_test.go
+++ b/internal/provider/ipsstatus_data_source_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccIPSStatusDataSource_basic(t *testing.T) {
+	t.Skip("Skipping: IPS requires a license not enabled on the CI tenant")
 	dataSourceName := "data.netskope_ips_status.test"
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
## Summary

Skip 7 tests that fail due to missing tenant licenses on the CI environment:
- 4 destination profile tests (resource CRUD + data sources)
- 2 destination profile drift detection tests  
- 1 IPS status data source test

All return 403 "This is a licensed feature" / "No IPS license enabled".

## Test plan

- [x] All other tests unaffected
- [ ] Unskip when licenses are enabled on CI tenant