### PR TITLE
Skip block rule tests that cannot pass with API tokens

### DIFF
--- a/internal/provider/drift_detection_test.go
+++ b/internal/provider/drift_detection_test.go
@@ -1560,6 +1560,8 @@ resource "netskope_destination_profile" "test" {
 // the plan modifier suppresses the diff against the config display name.
 // See: https://github.com/netskopeoss/terraform-provider-netskope/issues/79
 func TestAccDrift_NPARules_BlockTemplate(t *testing.T) {
+	t.Skip("API tokens cannot create block rules — KNOWN_API_ISSUES #13")
+
 	rName := fmt.Sprintf("%s-%s", testAccResourcePrefix, acctest.RandString(8))
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/nparules_resource_test.go
+++ b/internal/provider/nparules_resource_test.go
@@ -116,6 +116,7 @@ func TestAccNPARules_import(t *testing.T) {
 }
 
 func TestAccNPARules_denyRule(t *testing.T) {
+	t.Skip("API tokens cannot create block rules — KNOWN_API_ISSUES #13")
 
 	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
 	resourceName := "netskope_npa_rules.test"


### PR DESCRIPTION
## Summary

- Skip `TestAccNPARules_denyRule` and `TestAccDrift_NPARules_BlockTemplate` — API tokens cannot resolve notification templates for block rules (KNOWN_API_ISSUES #13), so these always fail in CI
- Block rule drift suppression was verified manually via import (issue #79, closed)

## Test plan

- [x] Both tests now report `--- SKIP` instead of `--- FAIL`
- [x] CI acceptance tests pass cleanly (no false failures)