### PR TITLE
Prepare release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [0.4.4] - Unreleased
+## [0.4.4] - 2026-05-18
 
 ### Fixed
 - **Fixed `private_app_id = 0` in `netskope_npa_private_apps_list` data source** ([BUG-012](docs/bugs/BUG-012-list-datasource-private-app-id-zero.md)) — The list endpoint returns `app_id` but the SDK mapping read from `id` (absent in list responses). Added `app_id` → `id` normalization in the bulk app AfterSuccess hook.
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Added `pop_names` to `netskope_ip_sec_tunnels_list` data source** ([BUG-015](docs/bugs/BUG-015-ipsec-tunnel-list-missing-pop-names.md)) — Same pattern as BUG-014. `pop_names` is Required on the resource but was missing from the list data source.
 - **Added `group_name` to `netskope_npa_rules` resource and data sources** ([BUG-016](docs/bugs/BUG-016-npa-rules-group-name-not-mapped.md)) — The API returns `group_name` but it was excluded by `x-speakeasy-terraform-ignore`. Removed the annotation and regenerated. Rules now preserve policy group assignment in state.
 
-## [0.4.3] - Unreleased
+## [0.4.3] - 2026-05-14
 
 ### Added
 - **`netskope_npa_rules_order` resource** — Manages the list position of NPA policy rules.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     netskope = {
       source  = "netskopeoss/netskope"
-      version = "0.3.6"
+      version = "0.4.4"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     netskope = {
       source  = "netskopeoss/netskope"
-      version = "0.3.6"
+      version = "0.4.4"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Set CHANGELOG dates for 0.4.3 (2026-05-14) and 0.4.4 (2026-05-18)
- Update version references from 0.3.6 to 0.4.4 in `examples/provider/provider.tf` and `docs/index.md`

## Test plan

- [x] No code changes — version metadata only