### PR TITLE
Prepare release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-05-29
+
 ### Added
 - **`netskope_urllist` resource** — Manage URL lists for Netskope policies. Supports create, read, update, delete, and import. Changes are auto-deployed via hooks.
 - **`netskope_urllist` data source** — Look up a single URL list by ID.


### PR DESCRIPTION
Promotes [Unreleased] changelog entries to [0.4.5] - 2026-05-29.

Changes included in this release (already merged via #85):
- `netskope_urllist` resource and data sources
- Fix `netskope_npa_rules_order` ignoring provider-level credentials (#80)
- Fix nil panic in `hookMyPolicyBeforeRequest` when updating rule order only
- Known API Issues #16: NPA rules ordering eventual consistency