### PR TITLE
Add AI Gateway resources and acceptance tests (v0.4.6)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v5.5.0
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -41,10 +41,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v5.5.0
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/internal/provider/aigaiprovider_resource_test.go
+++ b/internal/provider/aigaiprovider_resource_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/netskopeoss/terraform-provider-netskope/internal/provider/testutil"
+)
+
+// AIG AI provider names must start with "cust-" and be ≤15 chars.
+// We use "cust-tf" (7 chars) + 7 random = 14 chars total.
+func aigAiProviderTestName() string {
+	return "cust-tf" + acctest.RandString(7)
+}
+
+func TestAccAIGAiProvider_basic(t *testing.T) {
+	rName := aigAiProviderTestName()
+	resourceName := "netskope_aig_ai_provider.test"
+	vars := config.Variables{
+		"name": config.StringVariable(rName),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_ai_provider"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: vars,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "host", "ai-backend.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "https-skip"),
+					resource.TestCheckResourceAttr(resourceName, "schema", "openai"),
+					resource.TestCheckResourceAttr(resourceName, "type", "custom"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ConfigDirectory:   config.TestNameDirectory(),
+				ConfigVariables:   vars,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAIGAiProvider_update(t *testing.T) {
+	rName := aigAiProviderTestName()
+	resourceName := "netskope_aig_ai_provider.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_ai_provider"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+					"host": config.StringVariable("ai-backend.example.com"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "host", "ai-backend.example.com"),
+				),
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+					"host": config.StringVariable("ai-backend-updated.example.com"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "host", "ai-backend-updated.example.com"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAIGAiProviderDataSource_basic(t *testing.T) {
+	rName := aigAiProviderTestName()
+	resourceName := "netskope_aig_ai_provider.test"
+	dataSourceName := "data.netskope_aig_ai_provider.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_ai_provider"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "host", resourceName, "host"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "schema", resourceName, "schema"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "type", resourceName, "type"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAIGAiProviderListDataSource_basic(t *testing.T) {
+	rName := aigAiProviderTestName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_ai_provider"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.netskope_aig_ai_provider_list.test", "elements.#"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/aigmcpserver_resource_test.go
+++ b/internal/provider/aigmcpserver_resource_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/netskopeoss/terraform-provider-netskope/internal/provider/testutil"
+)
+
+// AIG MCP server names must start with "mcp-cust-" and be ≤19 chars.
+// We use "mcp-cust-tf" (11 chars) + 7 random = 18 chars total.
+func aigMcpServerTestName() string {
+	return "mcp-cust-tf" + acctest.RandString(7)
+}
+
+func TestAccAIGMcpServer_basic(t *testing.T) {
+	rName := aigMcpServerTestName()
+	resourceName := "netskope_aig_mcp_server.test"
+	vars := config.Variables{
+		"name": config.StringVariable(rName),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_mcp_server"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: vars,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "host", "mcp-backend.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/mcp"),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "http"),
+					resource.TestCheckResourceAttr(resourceName, "schema", "mcp-http"),
+					resource.TestCheckResourceAttr(resourceName, "type", "custom"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ConfigDirectory:   config.TestNameDirectory(),
+				ConfigVariables:   vars,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAIGMcpServer_update(t *testing.T) {
+	rName := aigMcpServerTestName()
+	resourceName := "netskope_aig_mcp_server.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_mcp_server"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+					"path": config.StringVariable("/mcp"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/mcp"),
+				),
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+					"path": config.StringVariable("/mcp/v2"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/mcp/v2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAIGMcpServerDataSource_basic(t *testing.T) {
+	rName := aigMcpServerTestName()
+	resourceName := "netskope_aig_mcp_server.test"
+	dataSourceName := "data.netskope_aig_mcp_server.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_mcp_server"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "host", resourceName, "host"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "path", resourceName, "path"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "schema", resourceName, "schema"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAIGMcpServerListDataSource_basic(t *testing.T) {
+	rName := aigMcpServerTestName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_mcp_server"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.netskope_aig_mcp_server_list.test", "elements.#"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/aigratelimit_resource_test.go
+++ b/internal/provider/aigratelimit_resource_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/netskopeoss/terraform-provider-netskope/internal/provider/testutil"
+)
+
+// AIG rate limit names are ≤15 chars with no prefix requirement.
+// We use "tfrl" (4 chars) + 10 random = 14 chars total.
+func aigRateLimitTestName() string {
+	return "tfrl" + acctest.RandString(10)
+}
+
+func TestAccAIGRateLimit_basic(t *testing.T) {
+	rName := aigRateLimitTestName()
+	resourceName := "netskope_aig_rate_limit.test"
+	vars := config.Variables{
+		"name": config.StringVariable(rName),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_rate_limit"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: vars,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "criteria.apply_on", "ai"),
+					resource.TestCheckResourceAttr(resourceName, "limit.requests", "100"),
+					resource.TestCheckResourceAttr(resourceName, "limit.unit", "hour"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ConfigDirectory:   config.TestNameDirectory(),
+				ConfigVariables:   vars,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAIGRateLimit_update(t *testing.T) {
+	rName := aigRateLimitTestName()
+	resourceName := "netskope_aig_rate_limit.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_rate_limit"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name":     config.StringVariable(rName),
+					"requests": config.IntegerVariable(100),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "limit.requests", "100"),
+				),
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name":     config.StringVariable(rName),
+					"requests": config.IntegerVariable(200),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "limit.requests", "200"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAIGRateLimitDataSource_basic(t *testing.T) {
+	rName := aigRateLimitTestName()
+	resourceName := "netskope_aig_rate_limit.test"
+	dataSourceName := "data.netskope_aig_rate_limit.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_rate_limit"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "criteria.apply_on", resourceName, "criteria.apply_on"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "limit.requests", resourceName, "limit.requests"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "limit.unit", resourceName, "limit.unit"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAIGRateLimitListDataSource_basic(t *testing.T) {
+	rName := aigRateLimitTestName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_rate_limit"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.netskope_aig_rate_limit_list.test", "elements.#"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/aigtoken_resource_test.go
+++ b/internal/provider/aigtoken_resource_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/netskopeoss/terraform-provider-netskope/internal/provider/testutil"
+)
+
+func TestAccAIGToken_basic(t *testing.T) {
+	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
+	resourceName := "netskope_aig_token.test"
+	vars := config.Variables{
+		"name": config.StringVariable(rName),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_token_group"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: vars,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "token_group_id"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAIGToken_update(t *testing.T) {
+	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
+	rNameUpdated := fmt.Sprintf("%s-upd", rName)
+	resourceName := "netskope_aig_token.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_token_group"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name":       config.StringVariable(rName),
+					"token_name": config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name":       config.StringVariable(rName),
+					"token_name": config.StringVariable(rNameUpdated),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAIGTokenDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
+	resourceName := "netskope_aig_token.test"
+	dataSourceName := "data.netskope_aig_token.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_token_group"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "token_group_id", resourceName, "token_group_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "enabled", resourceName, "enabled"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAIGTokenListDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_token_group"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.netskope_aig_token_list.test", "elements.#"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/aigtokengroup_resource_test.go
+++ b/internal/provider/aigtokengroup_resource_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/netskopeoss/terraform-provider-netskope/internal/provider/testutil"
+)
+
+func TestAccAIGTokenGroup_basic(t *testing.T) {
+	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
+	resourceName := "netskope_aig_token_group.test"
+	vars := config.Variables{
+		"name": config.StringVariable(rName),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_token_group"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: vars,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test token group"),
+					resource.TestCheckResourceAttr(resourceName, "token_count", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ConfigDirectory:   config.TestNameDirectory(),
+				ConfigVariables:   vars,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAIGTokenGroup_update(t *testing.T) {
+	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
+	resourceName := "netskope_aig_token_group.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_token_group"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name":        config.StringVariable(rName),
+					"description": config.StringVariable("Initial description"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Initial description"),
+				),
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name":        config.StringVariable(rName),
+					"description": config.StringVariable("Updated description"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated description"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAIGTokenGroupDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
+	resourceName := "netskope_aig_token_group.test"
+	dataSourceName := "data.netskope_aig_token_group.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_token_group"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "token_count", resourceName, "token_count"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAIGTokenGroupListDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_aig_token_group"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.netskope_aig_token_group_list.test", "elements.#"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/drift_detection_test.go
+++ b/internal/provider/drift_detection_test.go
@@ -1799,3 +1799,221 @@ resource "netskope_aig_appliance" "test" {
 }
 `, testAccProviderConfig(), name, name)
 }
+
+// TestAccDrift_AIGAiProvider verifies no drift on AIG AI provider resources.
+// Key computed field: type (always "custom" for user-managed providers).
+func TestAccDrift_AIGAiProvider(t *testing.T) {
+	// Names must start with "cust-" and be ≤15 chars
+	rName := "cust-tf" + acctest.RandString(7)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckResourceDestroy("netskope_aig_ai_provider"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDriftAIGAiProviderConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResourceExists("netskope_aig_ai_provider.test", "id"),
+				),
+			},
+			{
+				Config: testAccDriftAIGAiProviderConfig(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccDriftAIGAiProviderConfig(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "netskope_aig_ai_provider" "test" {
+  name     = %q
+  host     = "ai-backend.example.com"
+  port     = 443
+  protocol = "https-skip"
+  schema   = "openai"
+}
+`, testAccProviderConfig(), name)
+}
+
+// TestAccDrift_AIGMcpServer verifies no drift on AIG MCP server resources.
+// Key computed fields: schema (has default "mcp-http"), type (always "custom").
+func TestAccDrift_AIGMcpServer(t *testing.T) {
+	// Names must start with "mcp-cust-" and be ≤19 chars
+	rName := "mcp-cust-tf" + acctest.RandString(7)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckResourceDestroy("netskope_aig_mcp_server"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDriftAIGMcpServerConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResourceExists("netskope_aig_mcp_server.test", "id"),
+				),
+			},
+			{
+				Config: testAccDriftAIGMcpServerConfig(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccDriftAIGMcpServerConfig(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "netskope_aig_mcp_server" "test" {
+  name     = %q
+  host     = "mcp-backend.example.com"
+  port     = 8080
+  path     = "/mcp"
+  protocol = "http"
+}
+`, testAccProviderConfig(), name)
+}
+
+// TestAccDrift_AIGRateLimit verifies no drift on AIG rate limit resources.
+func TestAccDrift_AIGRateLimit(t *testing.T) {
+	rName := "tfrl" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckResourceDestroy("netskope_aig_rate_limit"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDriftAIGRateLimitConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResourceExists("netskope_aig_rate_limit.test", "id"),
+				),
+			},
+			{
+				Config: testAccDriftAIGRateLimitConfig(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccDriftAIGRateLimitConfig(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "netskope_aig_rate_limit" "test" {
+  name = %q
+
+  criteria = {
+    apply_on = "ai"
+  }
+
+  limit = {
+    requests = 100
+    unit     = "hour"
+  }
+}
+`, testAccProviderConfig(), name)
+}
+
+// TestAccDrift_AIGTokenGroup verifies no drift on AIG token group resources.
+// Key computed field: token_count (increments as tokens are added).
+func TestAccDrift_AIGTokenGroup(t *testing.T) {
+	rName := fmt.Sprintf("%s-%s", testAccResourcePrefix, acctest.RandString(8))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckResourceDestroy("netskope_aig_token_group"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDriftAIGTokenGroupConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResourceExists("netskope_aig_token_group.test", "id"),
+				),
+			},
+			{
+				Config: testAccDriftAIGTokenGroupConfig(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccDriftAIGTokenGroupConfig(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "netskope_aig_token_group" "test" {
+  name        = %q
+  description = "Drift detection test group"
+}
+`, testAccProviderConfig(), name)
+}
+
+// TestAccDrift_AIGToken verifies no drift on AIG token resources.
+// Key computed fields: enabled, expire_time.
+func TestAccDrift_AIGToken(t *testing.T) {
+	rName := fmt.Sprintf("%s-%s", testAccResourcePrefix, acctest.RandString(8))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckResourceDestroy("netskope_aig_token_group"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDriftAIGTokenConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResourceExists("netskope_aig_token.test", "id"),
+				),
+			},
+			{
+				Config: testAccDriftAIGTokenConfig(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccDriftAIGTokenConfig(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "netskope_aig_token_group" "test" {
+  name = %q
+}
+
+resource "netskope_aig_token" "test" {
+  name           = %q
+  token_group_id = netskope_aig_token_group.test.id
+  expire_in = {
+    unit  = "month"
+    value = 1
+  }
+}
+`, testAccProviderConfig(), name, name)
+}

--- a/internal/provider/sweep_test.go
+++ b/internal/provider/sweep_test.go
@@ -63,6 +63,37 @@ func init() {
 		F:            sweepAIGAppliances,
 		Dependencies: []string{},
 	})
+
+	resource.AddTestSweepers("netskope_aig_ai_provider", &resource.Sweeper{
+		Name:         "netskope_aig_ai_provider",
+		F:            sweepAIGAiProviders,
+		Dependencies: []string{},
+	})
+
+	resource.AddTestSweepers("netskope_aig_mcp_server", &resource.Sweeper{
+		Name:         "netskope_aig_mcp_server",
+		F:            sweepAIGMcpServers,
+		Dependencies: []string{},
+	})
+
+	resource.AddTestSweepers("netskope_aig_rate_limit", &resource.Sweeper{
+		Name:         "netskope_aig_rate_limit",
+		F:            sweepAIGRateLimits,
+		Dependencies: []string{},
+	})
+
+	// Tokens must be swept before the groups they belong to
+	resource.AddTestSweepers("netskope_aig_token", &resource.Sweeper{
+		Name:         "netskope_aig_token",
+		F:            sweepAIGTokens,
+		Dependencies: []string{},
+	})
+
+	resource.AddTestSweepers("netskope_aig_token_group", &resource.Sweeper{
+		Name:         "netskope_aig_token_group",
+		F:            sweepAIGTokenGroups,
+		Dependencies: []string{"netskope_aig_token"},
+	})
 }
 
 // TestMain runs the sweepers if the -sweep flag is passed
@@ -399,6 +430,184 @@ func sweepAIGAppliances(region string) error {
 		})
 		if err != nil {
 			log.Printf("[WARN] Error deleting AIG appliance %s: %s", appliance.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func sweepAIGAiProviders(region string) error {
+	client, err := getSweepClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	res, err := client.AIGAiProviders.ListObjects(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing AIG AI providers for sweeping: %w", err)
+	}
+
+	if res.AigAiProviderListResponse == nil {
+		return nil
+	}
+
+	// Test AI provider names use "cust-tf" prefix (constraint: must start with "cust-")
+	for _, provider := range res.AigAiProviderListResponse.Elements {
+		if !strings.HasPrefix(provider.Name, "cust-tf") {
+			continue
+		}
+
+		log.Printf("[INFO] Sweeping AIG AI Provider: %s (ID: %s)", provider.Name, provider.ID)
+
+		_, err := client.AIGAiProvider.Delete(ctx, operations.DeleteAigAiProviderRequest{
+			ProviderID: provider.ID,
+		})
+		if err != nil {
+			log.Printf("[WARN] Error deleting AIG AI provider %s: %s", provider.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func sweepAIGMcpServers(region string) error {
+	client, err := getSweepClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	res, err := client.AIGMcpServers.ListObjects(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing AIG MCP servers for sweeping: %w", err)
+	}
+
+	if res.AigMcpServerListResponse == nil {
+		return nil
+	}
+
+	// Test MCP server names use "mcp-cust-tf" prefix (constraint: must start with "mcp-cust-")
+	for _, server := range res.AigMcpServerListResponse.Elements {
+		if !strings.HasPrefix(server.Name, "mcp-cust-tf") {
+			continue
+		}
+
+		log.Printf("[INFO] Sweeping AIG MCP Server: %s (ID: %s)", server.Name, server.ID)
+
+		_, err := client.AIGMcpServer.Delete(ctx, operations.DeleteAigMcpServerRequest{
+			ServerID: server.ID,
+		})
+		if err != nil {
+			log.Printf("[WARN] Error deleting AIG MCP server %s: %s", server.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func sweepAIGRateLimits(region string) error {
+	client, err := getSweepClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	res, err := client.AIGRateLimits.ListObjects(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing AIG rate limits for sweeping: %w", err)
+	}
+
+	if res.AigRateLimitListResponse == nil {
+		return nil
+	}
+
+	// Test rate limit names use "tfrl" prefix
+	for _, rule := range res.AigRateLimitListResponse.Elements {
+		if !strings.HasPrefix(rule.Name, "tfrl") {
+			continue
+		}
+
+		log.Printf("[INFO] Sweeping AIG Rate Limit: %s (ID: %s)", rule.Name, rule.ID)
+
+		_, err := client.AIGRateLimit.Delete(ctx, operations.DeleteAigRateLimitRequest{
+			RuleID: rule.ID,
+		})
+		if err != nil {
+			log.Printf("[WARN] Error deleting AIG rate limit %s: %s", rule.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func sweepAIGTokens(region string) error {
+	client, err := getSweepClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	res, err := client.AIGTokens.ListObjects(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing AIG tokens for sweeping: %w", err)
+	}
+
+	if res.AigTokenListResponse == nil {
+		return nil
+	}
+
+	for _, token := range res.AigTokenListResponse.Elements {
+		if !strings.HasPrefix(token.Name, testAccResourcePrefix) {
+			continue
+		}
+
+		log.Printf("[INFO] Sweeping AIG Token: %s (ID: %s)", token.Name, token.ID)
+
+		_, err := client.AIGToken.Delete(ctx, operations.DeleteAigTokenRequest{
+			TokenID: token.ID,
+		})
+		if err != nil {
+			log.Printf("[WARN] Error deleting AIG token %s: %s", token.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func sweepAIGTokenGroups(region string) error {
+	client, err := getSweepClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	res, err := client.AIGTokenGroups.ListObjects(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing AIG token groups for sweeping: %w", err)
+	}
+
+	if res.AigTokenGroupListResponse == nil {
+		return nil
+	}
+
+	for _, group := range res.AigTokenGroupListResponse.Elements {
+		if !strings.HasPrefix(group.Name, testAccResourcePrefix) {
+			continue
+		}
+
+		log.Printf("[INFO] Sweeping AIG Token Group: %s (ID: %s)", group.Name, group.ID)
+
+		_, err := client.AIGTokenGroup.Delete(ctx, operations.DeleteAigTokenGroupRequest{
+			GroupID: group.ID,
+		})
+		if err != nil {
+			log.Printf("[WARN] Error deleting AIG token group %s: %s", group.Name, err)
 		}
 	}
 

--- a/internal/provider/testdata/TestAccAIGAiProviderDataSource_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGAiProviderDataSource_basic/main.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_ai_provider" "test" {
+  name     = var.name
+  host     = "ai-backend.example.com"
+  port     = 443
+  protocol = "https-skip"
+  schema   = "openai"
+}
+
+data "netskope_aig_ai_provider" "test" {
+  id = netskope_aig_ai_provider.test.id
+}

--- a/internal/provider/testdata/TestAccAIGAiProviderListDataSource_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGAiProviderListDataSource_basic/main.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_ai_provider" "test" {
+  name     = var.name
+  host     = "ai-backend.example.com"
+  port     = 443
+  protocol = "https-skip"
+  schema   = "openai"
+}
+
+data "netskope_aig_ai_provider_list" "test" {
+  depends_on = [netskope_aig_ai_provider.test]
+}

--- a/internal/provider/testdata/TestAccAIGAiProvider_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGAiProvider_basic/main.tf
@@ -1,0 +1,11 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_ai_provider" "test" {
+  name     = var.name
+  host     = "ai-backend.example.com"
+  port     = 443
+  protocol = "https-skip"
+  schema   = "openai"
+}

--- a/internal/provider/testdata/TestAccAIGAiProvider_update/main.tf
+++ b/internal/provider/testdata/TestAccAIGAiProvider_update/main.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  type = string
+}
+
+variable "host" {
+  type = string
+}
+
+resource "netskope_aig_ai_provider" "test" {
+  name     = var.name
+  host     = var.host
+  port     = 443
+  protocol = "https-skip"
+  schema   = "openai"
+}

--- a/internal/provider/testdata/TestAccAIGMcpServerDataSource_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGMcpServerDataSource_basic/main.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_mcp_server" "test" {
+  name     = var.name
+  host     = "mcp-backend.example.com"
+  port     = 8080
+  path     = "/mcp"
+  protocol = "http"
+}
+
+data "netskope_aig_mcp_server" "test" {
+  id = netskope_aig_mcp_server.test.id
+}

--- a/internal/provider/testdata/TestAccAIGMcpServerListDataSource_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGMcpServerListDataSource_basic/main.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_mcp_server" "test" {
+  name     = var.name
+  host     = "mcp-backend.example.com"
+  port     = 8080
+  path     = "/mcp"
+  protocol = "http"
+}
+
+data "netskope_aig_mcp_server_list" "test" {
+  depends_on = [netskope_aig_mcp_server.test]
+}

--- a/internal/provider/testdata/TestAccAIGMcpServer_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGMcpServer_basic/main.tf
@@ -1,0 +1,11 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_mcp_server" "test" {
+  name     = var.name
+  host     = "mcp-backend.example.com"
+  port     = 8080
+  path     = "/mcp"
+  protocol = "http"
+}

--- a/internal/provider/testdata/TestAccAIGMcpServer_update/main.tf
+++ b/internal/provider/testdata/TestAccAIGMcpServer_update/main.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  type = string
+}
+
+variable "path" {
+  type = string
+}
+
+resource "netskope_aig_mcp_server" "test" {
+  name     = var.name
+  host     = "mcp-backend.example.com"
+  port     = 8080
+  path     = var.path
+  protocol = "http"
+}

--- a/internal/provider/testdata/TestAccAIGRateLimitDataSource_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGRateLimitDataSource_basic/main.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_rate_limit" "test" {
+  name = var.name
+
+  criteria = {
+    apply_on = "ai"
+  }
+
+  limit = {
+    requests = 100
+    unit     = "hour"
+  }
+}
+
+data "netskope_aig_rate_limit" "test" {
+  id = netskope_aig_rate_limit.test.id
+}

--- a/internal/provider/testdata/TestAccAIGRateLimitListDataSource_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGRateLimitListDataSource_basic/main.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_rate_limit" "test" {
+  name = var.name
+
+  criteria = {
+    apply_on = "ai"
+  }
+
+  limit = {
+    requests = 100
+    unit     = "hour"
+  }
+}
+
+data "netskope_aig_rate_limit_list" "test" {
+  depends_on = [netskope_aig_rate_limit.test]
+}

--- a/internal/provider/testdata/TestAccAIGRateLimit_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGRateLimit_basic/main.tf
@@ -1,0 +1,16 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_rate_limit" "test" {
+  name = var.name
+
+  criteria = {
+    apply_on = "ai"
+  }
+
+  limit = {
+    requests = 100
+    unit     = "hour"
+  }
+}

--- a/internal/provider/testdata/TestAccAIGRateLimit_update/main.tf
+++ b/internal/provider/testdata/TestAccAIGRateLimit_update/main.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  type = string
+}
+
+variable "requests" {
+  type = number
+}
+
+resource "netskope_aig_rate_limit" "test" {
+  name = var.name
+
+  criteria = {
+    apply_on = "ai"
+  }
+
+  limit = {
+    requests = var.requests
+    unit     = "hour"
+  }
+}

--- a/internal/provider/testdata/TestAccAIGTokenDataSource_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGTokenDataSource_basic/main.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_token_group" "test" {
+  name = var.name
+}
+
+resource "netskope_aig_token" "test" {
+  name           = var.name
+  token_group_id = netskope_aig_token_group.test.id
+  expire_in = {
+    unit  = "month"
+    value = 1
+  }
+}
+
+data "netskope_aig_token" "test" {
+  id = netskope_aig_token.test.id
+}

--- a/internal/provider/testdata/TestAccAIGTokenGroupDataSource_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGTokenGroupDataSource_basic/main.tf
@@ -1,0 +1,12 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_token_group" "test" {
+  name        = var.name
+  description = "Test token group"
+}
+
+data "netskope_aig_token_group" "test" {
+  id = netskope_aig_token_group.test.id
+}

--- a/internal/provider/testdata/TestAccAIGTokenGroupListDataSource_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGTokenGroupListDataSource_basic/main.tf
@@ -1,0 +1,12 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_token_group" "test" {
+  name        = var.name
+  description = "Test token group"
+}
+
+data "netskope_aig_token_group_list" "test" {
+  depends_on = [netskope_aig_token_group.test]
+}

--- a/internal/provider/testdata/TestAccAIGTokenGroup_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGTokenGroup_basic/main.tf
@@ -1,0 +1,8 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_token_group" "test" {
+  name        = var.name
+  description = "Test token group"
+}

--- a/internal/provider/testdata/TestAccAIGTokenGroup_update/main.tf
+++ b/internal/provider/testdata/TestAccAIGTokenGroup_update/main.tf
@@ -1,0 +1,12 @@
+variable "name" {
+  type = string
+}
+
+variable "description" {
+  type = string
+}
+
+resource "netskope_aig_token_group" "test" {
+  name        = var.name
+  description = var.description
+}

--- a/internal/provider/testdata/TestAccAIGTokenListDataSource_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGTokenListDataSource_basic/main.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_token_group" "test" {
+  name = var.name
+}
+
+resource "netskope_aig_token" "test" {
+  name           = var.name
+  token_group_id = netskope_aig_token_group.test.id
+  expire_in = {
+    unit  = "month"
+    value = 1
+  }
+}
+
+data "netskope_aig_token_list" "test" {
+  depends_on = [netskope_aig_token.test]
+}

--- a/internal/provider/testdata/TestAccAIGToken_basic/main.tf
+++ b/internal/provider/testdata/TestAccAIGToken_basic/main.tf
@@ -1,0 +1,16 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_aig_token_group" "test" {
+  name = var.name
+}
+
+resource "netskope_aig_token" "test" {
+  name           = var.name
+  token_group_id = netskope_aig_token_group.test.id
+  expire_in = {
+    unit  = "month"
+    value = 1
+  }
+}

--- a/internal/provider/testdata/TestAccAIGToken_update/main.tf
+++ b/internal/provider/testdata/TestAccAIGToken_update/main.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  type = string
+}
+
+variable "token_name" {
+  type = string
+}
+
+resource "netskope_aig_token_group" "test" {
+  name = var.name
+}
+
+resource "netskope_aig_token" "test" {
+  name           = var.token_name
+  token_group_id = netskope_aig_token_group.test.id
+  expire_in = {
+    unit  = "month"
+    value = 1
+  }
+}

--- a/internal/sdk/internal/hooks/hookAIGRateLimitRequest.go
+++ b/internal/sdk/internal/hooks/hookAIGRateLimitRequest.go
@@ -1,0 +1,70 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// aigRateLimitRequestHook strips criteria fields that are excluded by the API
+// based on the value of apply_on:
+//   - apply_on = "ai"  → mcp_server_ids, tools, resources, prompts are excluded
+//   - apply_on = "mcp" → ai_provider_ids, models are excluded
+//
+// The SDK serializes Computed+Optional list fields as [] when unset, but the
+// API rejects any excluded field even when empty.
+type aigRateLimitRequestHook struct{}
+
+var _ beforeRequestHook = (*aigRateLimitRequestHook)(nil)
+
+func (h *aigRateLimitRequestHook) BeforeRequest(hookCtx BeforeRequestContext, req *http.Request) (*http.Request, error) {
+	if hookCtx.OperationID != "createAigRateLimit" && hookCtx.OperationID != "updateAigRateLimit" {
+		return req, nil
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("aigRateLimitRequestHook: unable to read request body: %w", err)
+	}
+
+	var requestMap map[string]interface{}
+	if err := json.Unmarshal(body, &requestMap); err != nil {
+		return nil, fmt.Errorf("aigRateLimitRequestHook: unable to unmarshal request: %w", err)
+	}
+
+	criteria, ok := requestMap["criteria"].(map[string]interface{})
+	if !ok {
+		// No criteria object — nothing to strip.
+		req.Body = io.NopCloser(strings.NewReader(string(body)))
+		return req, nil
+	}
+
+	applyOn, _ := criteria["apply_on"].(string)
+
+	switch applyOn {
+	case "ai":
+		// MCP-specific fields are excluded when apply_on = "ai"
+		for _, field := range []string{"mcp_server_ids", "tools", "resources", "prompts"} {
+			delete(criteria, field)
+		}
+	case "mcp":
+		// AI-specific fields are excluded when apply_on = "mcp"
+		for _, field := range []string{"ai_provider_ids", "models"} {
+			delete(criteria, field)
+		}
+	}
+
+	requestMap["criteria"] = criteria
+
+	modifiedBody, err := json.Marshal(requestMap)
+	if err != nil {
+		return nil, fmt.Errorf("aigRateLimitRequestHook: unable to marshal modified request: %w", err)
+	}
+
+	req.Body = io.NopCloser(strings.NewReader(string(modifiedBody)))
+	req.ContentLength = int64(len(modifiedBody))
+
+	return req, nil
+}

--- a/internal/sdk/internal/hooks/hookAIGTokenRequest.go
+++ b/internal/sdk/internal/hooks/hookAIGTokenRequest.go
@@ -1,0 +1,61 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// aigTokenRequestHook removes expire_in from token create/update requests when
+// it was not explicitly configured. The Terraform framework can populate the
+// expire_in nested object with zero values (value=0, unit="") when the attribute
+// is null in the plan — the API rejects these as invalid.
+type aigTokenRequestHook struct{}
+
+var _ beforeRequestHook = (*aigTokenRequestHook)(nil)
+
+func (h *aigTokenRequestHook) BeforeRequest(hookCtx BeforeRequestContext, req *http.Request) (*http.Request, error) {
+	if hookCtx.OperationID != "createAigToken" && hookCtx.OperationID != "updateAigToken" {
+		return req, nil
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("aigTokenRequestHook: unable to read request body: %w", err)
+	}
+
+	var requestMap map[string]interface{}
+	if err := json.Unmarshal(body, &requestMap); err != nil {
+		return nil, fmt.Errorf("aigTokenRequestHook: unable to unmarshal request: %w", err)
+	}
+
+	if expireIn, ok := requestMap["expire_in"]; ok {
+		// Remove expire_in if it's nil or if value/unit are zero/empty
+		remove := false
+		switch v := expireIn.(type) {
+		case nil:
+			remove = true
+		case map[string]interface{}:
+			unit, _ := v["unit"].(string)
+			value, _ := v["value"].(float64)
+			if unit == "" || value == 0 {
+				remove = true
+			}
+		}
+		if remove {
+			delete(requestMap, "expire_in")
+		}
+	}
+
+	modifiedBody, err := json.Marshal(requestMap)
+	if err != nil {
+		return nil, fmt.Errorf("aigTokenRequestHook: unable to marshal modified request: %w", err)
+	}
+
+	req.Body = io.NopCloser(strings.NewReader(string(modifiedBody)))
+	req.ContentLength = int64(len(modifiedBody))
+
+	return req, nil
+}

--- a/internal/sdk/internal/hooks/registration.go
+++ b/internal/sdk/internal/hooks/registration.go
@@ -72,4 +72,12 @@ func initHooks(h *Hooks) {
 	// URL list - response transformations (deploy after CRUD, wrap list response)
 	urllist := &urllistAfterSuccess{}
 	h.registerAfterSuccessHook(urllist)
+
+	// AIG rate limit - strip criteria fields excluded by the API based on apply_on
+	aigRateLimit := &aigRateLimitRequestHook{}
+	h.registerBeforeRequestHook(aigRateLimit)
+
+	// AIG token - remove expire_in when not configured (zero values rejected by API)
+	aigToken := &aigTokenRequestHook{}
+	h.registerBeforeRequestHook(aigToken)
 }


### PR DESCRIPTION
## Summary

- Adds 15 new AIG resources and data sources: `aig_appliance`, `aig_appliance_enrollment_token`, `aig_ai_provider`, `aig_mcp_server`, `aig_rate_limit`, `aig_token`, `aig_token_group`, plus list/capacity/image data sources
- Adds acceptance tests for all new AIG resources (26 tests across 5 test files), sweepers, and drift detection tests
- Fixes two excluded-field API bugs via BeforeRequest hooks:
  - `hookAIGRateLimitRequest`: strips MCP-specific criteria fields when `apply_on=ai` (and vice versa) — API rejects excluded fields even when empty
  - `hookAIGTokenRequest`: strips `expire_in` when unit/value are zero — API rejects zero-value structs
- Fixes NPA policy source IP criteria bug (`npaprivateapp_resource_sdk.go`)
- Pins CI actions to Node.js 20-compatible versions to fix deprecation warning

## Test plan

- [ ] All 26 `TestAccAIG*` acceptance tests pass locally (verified)
- [ ] `TestAccAIGRateLimit_*` — covers `apply_on=ai` hook (strips excluded MCP fields)
- [ ] `TestAccAIGToken_*` — tokens use `expire_in = { unit = "month", value = 1 }` (API requires it despite OAS marking optional)
- [ ] Drift detection tests added for all 5 new resource types
- [ ] Sweepers registered for all 5 new resource types

## Known behavior

The Netskope API requires `expire_in` on token creation even though the OAS marks it optional. Creating a token without `expire_in` returns HTTP 400. Documentation and schema should note this requirement.