### PR TITLE
Install Terraform before acceptance tests to prevent checkpoint API timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,12 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+
       - name: Download dependencies
         run: go mod download
 


### PR DESCRIPTION
The test framework downloads Terraform on-demand when not found on PATH, contacting `checkpoint-api.hashicorp.com` which times out in CI. Pre-install Terraform 1.x via `hashicorp/setup-terraform` so the binary is always available before tests run.