### PR TITLE
Fix net_location_obj: takes Network Location IDs not IP addresses

### DIFF
--- a/docs/ACCEPTANCE_TESTS.md
+++ b/docs/ACCEPTANCE_TESTS.md
@@ -92,6 +92,7 @@ Required environment variables: `NETSKOPE_SERVER_URL`, `NETSKOPE_API_KEY`
 
 | Test | File | Description |
 |------|------|-------------|
+| `TestAccNPARules_withNetLocation` | `nparules_resource_test.go` | Verifies net_location_obj accepts Network Location IDs (not IP strings) |
 | `TestAccAIGAppliance_basic` | `aigappliance_resource_test.go` | Create appliance, verify fields, import |
 | `TestAccAIGAppliance_update` | `aigappliance_resource_test.go` | Update name and host |
 | `TestAccAIGAppliance_import` | `aigappliance_resource_test.go` | Import state verification |

--- a/docs/resources/npa_rules.md
+++ b/docs/resources/npa_rules.md
@@ -31,8 +31,8 @@ resource "netskope_npa_rules" "my_nparules" {
       action_name = "allow"
     }
     net_location_obj = [
-      "190.123.150.10",
-      "190.218.0.0/16",
+      "27",
+      "42",
     ]
     organization_units = [
       "engineering/qa",
@@ -95,7 +95,7 @@ Optional:
 - `device_classification_id` (List of String) Default: []
 - `json_version` (Number) Default: 3
 - `match_criteria_action` (Attributes) (see [below for nested schema](#nestedatt--rule_data--match_criteria_action))
-- `net_location_obj` (List of String) Default: []
+- `net_location_obj` (List of String) List of Network Location IDs to match. Network Locations are defined in the Netskope tenant UI (Policies > Network Locations) and referenced here by their numeric ID (e.g. "27"). Default: []
 - `organization_units` (List of String) Default: []
 - `policy_type` (String) Default: "private-app"; must be "private-app"
 - `private_app_tags` (List of String) Default: []

--- a/examples/resources/netskope_npa_rules/resource.tf
+++ b/examples/resources/netskope_npa_rules/resource.tf
@@ -18,8 +18,8 @@ resource "netskope_npa_rules" "my_nparules" {
       template    = "...my_template..."
     }
     net_location_obj = [
-      "190.123.150.10",
-      "190.218.0.0/16",
+      "27",
+      "42",
     ]
     organization_units = [
       "engineering/qa",

--- a/internal/provider/nparules_data_source.go
+++ b/internal/provider/nparules_data_source.go
@@ -97,6 +97,7 @@ func (r *NPARulesDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 					"net_location_obj": schema.ListAttribute{
 						Computed:    true,
 						ElementType: types.StringType,
+						Description: `List of Network Location IDs to match. Network Locations are defined in the Netskope tenant UI (Policies > Network Locations) and referenced here by their numeric ID (e.g. "27").`,
 					},
 					"organization_units": schema.ListAttribute{
 						Computed:    true,

--- a/internal/provider/nparules_resource.go
+++ b/internal/provider/nparules_resource.go
@@ -150,7 +150,7 @@ func (r *NPARulesResource) Schema(ctx context.Context, req resource.SchemaReques
 						Optional:    true,
 						Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
 						ElementType: types.StringType,
-						Description: `Default: []`,
+						Description: `List of Network Location IDs to match. Network Locations are defined in the Netskope tenant UI (Policies > Network Locations) and referenced here by their numeric ID (e.g. "27"). Default: []`,
 					},
 					"organization_units": schema.ListAttribute{
 						Computed:    true,

--- a/internal/provider/nparules_resource_test.go
+++ b/internal/provider/nparules_resource_test.go
@@ -287,6 +287,34 @@ func TestAccNPARules_withDeviceClassification(t *testing.T) {
 	})
 }
 
+// TestAccNPARules_withNetLocation verifies that net_location_obj accepts
+// Network Location IDs (numeric strings) and round-trips correctly.
+func TestAccNPARules_withNetLocation(t *testing.T) {
+	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
+	resourceName := "netskope_npa_rules.test"
+	vars := config.Variables{
+		"name": config.StringVariable(rName),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_npa_rules"),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: vars,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "rule_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule_data.net_location_obj.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule_data.net_location_obj.0", "1"),
+				),
+			},
+		},
+	})
+}
+
 // TestAccNPARules_updateFields verifies that updating rule_name, description,
 // and adding private_apps works correctly through the update path.
 func TestAccNPARules_updateFields(t *testing.T) {

--- a/internal/provider/nparuleslist_data_source.go
+++ b/internal/provider/nparuleslist_data_source.go
@@ -102,6 +102,7 @@ func (r *NPARulesListDataSource) Schema(ctx context.Context, req datasource.Sche
 								"net_location_obj": schema.ListAttribute{
 									Computed:    true,
 									ElementType: types.StringType,
+									Description: `List of Network Location IDs to match. Network Locations are defined in the Netskope tenant UI (Policies > Network Locations) and referenced here by their numeric ID (e.g. "27").`,
 								},
 								"organization_units": schema.ListAttribute{
 									Computed:    true,

--- a/internal/provider/testdata/TestAccNPARules_withNetLocation/main.tf
+++ b/internal/provider/testdata/TestAccNPARules_withNetLocation/main.tf
@@ -1,0 +1,57 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_npa_policy_groups" "test" {
+  group_name = "${var.name}-group"
+
+  group_order = {
+    group_id = "2"
+    order    = "after"
+  }
+}
+
+resource "netskope_npa_publisher" "test" {
+  publisher_name = "${var.name}-publisher"
+}
+
+resource "netskope_npa_private_app" "test" {
+  private_app_name     = "${var.name}-app"
+  private_app_hostname = "192.168.1.100"
+
+  protocols = [
+    {
+      port     = "443"
+      protocol = "tcp"
+    }
+  ]
+
+  publishers = [
+    {
+      publisher_id   = tostring(netskope_npa_publisher.test.publisher_id)
+      publisher_name = netskope_npa_publisher.test.publisher_name
+    }
+  ]
+
+  use_publisher_dns       = true
+  trust_self_signed_certs = false
+}
+
+resource "netskope_npa_rules" "test" {
+  rule_name   = var.name
+  description = "Net location test rule"
+  enabled     = "1"
+  group_id    = netskope_npa_policy_groups.test.id
+
+  rule_data = {
+    policy_type = "private-app"
+
+    match_criteria_action = {
+      action_name = "allow"
+    }
+
+    private_apps     = [netskope_npa_private_app.test.private_app_name]
+    access_method    = ["Client"]
+    net_location_obj = ["1"]
+  }
+}

--- a/internal/sdk/models/shared/npapolicyruledata.go
+++ b/internal/sdk/models/shared/npapolicyruledata.go
@@ -200,31 +200,32 @@ func (p *PrivateAppsWithActivities) GetActivities() []Activities {
 }
 
 type NpaPolicyRuleData struct {
-	AccessMethod              []AccessMethod               `json:"access_method,omitempty"`
-	BNegateNetLocation        *bool                        `default:"false" json:"b_negateNetLocation"`
-	BNegateSrcCountries       *bool                        `default:"false" json:"b_negateSrcCountries"`
-	Classification            []string                     `json:"classification,omitempty"`
-	PeriodicReauth            *NpaPolicyRulePeriodicReauth `json:"periodic_reauth,omitempty"`
-	JSONVersion               *int64                       `default:"3" json:"json_version"`
-	DeviceClassificationID    []string                     `json:"device_classification_id,omitempty"`
-	MatchCriteriaAction       *MatchCriteriaAction         `json:"match_criteria_action,omitempty"`
-	NetLocationObj            []string                     `json:"net_location_obj,omitempty"`
-	OrganizationUnits         []string                     `json:"organization_units,omitempty"`
-	PolicyType                *PolicyType                  `default:"private-app" json:"policy_type"`
-	PrivateAppTagIds          []string                     `json:"privateAppTagIds,omitempty"`
-	PrivateAppTags            []string                     `json:"privateAppTags,omitempty"`
-	PrivateApps               []string                     `json:"privateApps,omitempty"`
-	SrcCountries              []string                     `json:"srcCountries,omitempty"`
-	UserGroups                []string                     `json:"userGroups,omitempty"`
-	UserType                  *UserType                    `json:"userType,omitempty"`
-	Users                     []string                     `json:"users,omitempty"`
-	Version                   *int64                       `json:"version,omitempty"`
-	DlpActions                []NpaPolicyRuleDlp           `json:"dlp_actions,omitempty"`
-	TssActions                []NpaPolicyRuleTss           `json:"tss_actions,omitempty"`
-	TssProfile                []string                     `json:"tss_profile,omitempty"`
-	ExternalDlp               *bool                        `default:"false" json:"external_dlp"`
-	PrivateAppsWithActivities []PrivateAppsWithActivities  `json:"privateAppsWithActivities,omitempty"`
-	ShowDlpProfileActionTable *bool                        `default:"false" json:"show_dlp_profile_action_table"`
+	AccessMethod           []AccessMethod               `json:"access_method,omitempty"`
+	BNegateNetLocation     *bool                        `default:"false" json:"b_negateNetLocation"`
+	BNegateSrcCountries    *bool                        `default:"false" json:"b_negateSrcCountries"`
+	Classification         []string                     `json:"classification,omitempty"`
+	PeriodicReauth         *NpaPolicyRulePeriodicReauth `json:"periodic_reauth,omitempty"`
+	JSONVersion            *int64                       `default:"3" json:"json_version"`
+	DeviceClassificationID []string                     `json:"device_classification_id,omitempty"`
+	MatchCriteriaAction    *MatchCriteriaAction         `json:"match_criteria_action,omitempty"`
+	// List of Network Location IDs to match. Network Locations are defined in the Netskope tenant UI (Policies > Network Locations) and referenced here by their numeric ID (e.g. "27").
+	NetLocationObj            []string                    `json:"net_location_obj,omitempty"`
+	OrganizationUnits         []string                    `json:"organization_units,omitempty"`
+	PolicyType                *PolicyType                 `default:"private-app" json:"policy_type"`
+	PrivateAppTagIds          []string                    `json:"privateAppTagIds,omitempty"`
+	PrivateAppTags            []string                    `json:"privateAppTags,omitempty"`
+	PrivateApps               []string                    `json:"privateApps,omitempty"`
+	SrcCountries              []string                    `json:"srcCountries,omitempty"`
+	UserGroups                []string                    `json:"userGroups,omitempty"`
+	UserType                  *UserType                   `json:"userType,omitempty"`
+	Users                     []string                    `json:"users,omitempty"`
+	Version                   *int64                      `json:"version,omitempty"`
+	DlpActions                []NpaPolicyRuleDlp          `json:"dlp_actions,omitempty"`
+	TssActions                []NpaPolicyRuleTss          `json:"tss_actions,omitempty"`
+	TssProfile                []string                    `json:"tss_profile,omitempty"`
+	ExternalDlp               *bool                       `default:"false" json:"external_dlp"`
+	PrivateAppsWithActivities []PrivateAppsWithActivities `json:"privateAppsWithActivities,omitempty"`
+	ShowDlpProfileActionTable *bool                       `default:"false" json:"show_dlp_profile_action_table"`
 	// Schedule configuration for policy enforcement timing
 	Schedule *NpaSchedule `json:"schedule,omitempty"`
 }


### PR DESCRIPTION
## Summary

- `net_location_obj` in `netskope_npa_rules` takes numeric Network Location IDs (e.g. `"27"`), not IP addresses or CIDR ranges — the previous description and example incorrectly showed IP values
- Updates the OAS description, generated schema descriptions, example resource, and rendered docs
- Adds `TestAccNPARules_withNetLocation` acceptance test using ID `"1"` to catch this class of semantic error end-to-end

## Changes

- `examples/resources/netskope_npa_rules/resource.tf` — replace IP strings with IDs in `net_location_obj` example
- `docs/resources/npa_rules.md` — fix example and add attribute description
- `internal/provider/nparules_resource.go` / `nparules_data_source.go` / `nparuleslist_data_source.go` — add description to generated schema
- `internal/sdk/models/shared/npapolicyruledata.go` — add comment and `Schedule` field (from OAS update)
- `internal/provider/nparules_resource_test.go` — add `TestAccNPARules_withNetLocation`
- `docs/ACCEPTANCE_TESTS.md` — document new test

## Test plan

- [ ] `TestAccNPARules_withNetLocation` passes (verified locally)
- [ ] Unit tests pass