### PR TITLE
fix(publisher): crash reading publishers with connected apps (BUG-017, #96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.4.7] - Unreleased
+
+### Fixed
+- **`netskope_npa_publisher` ReadResource crash for publishers with connected apps** ([BUG-017](docs/bugs/BUG-017-publisher-connected-apps-type-mismatch.md), [#96](https://github.com/netskopeoss/terraform-provider-netskope/issues/96)) — The `GET /infrastructure/publishers/{id}` endpoint changed `connected_apps` from an array of strings to an array of objects. The SDK struct still declared `[]string`, causing `json: cannot unmarshal object into Go value of type string` on every state refresh for publishers with at least one app connected. Fixed by excluding the field from SDK deserialization (`x-speakeasy-ignore`); it was already excluded from Terraform state. **Affects all releases from v0.3.3 onwards** — upgrade to v0.4.7 to resolve.
+
 ## [0.4.6] - 2026-06-29
 
 ### Added

--- a/docs/ACCEPTANCE_TESTS.md
+++ b/docs/ACCEPTANCE_TESTS.md
@@ -88,6 +88,12 @@ Required environment variables: `NETSKOPE_SERVER_URL`, `NETSKOPE_API_KEY`
 | `TestAccNPARules_ruleOrderBottom` | `nparules_resource_test.go` | Rule placement order=bottom verification |
 | `TestAccNPARules_ruleOrderBefore` | `nparules_resource_test.go` | Rule placement order=before verification |
 
+#### Added in v0.4.7
+
+| Test | File | Description |
+|------|------|-------------|
+| `TestAccPlatformOAuth2Token_basic` | `platformoauth2token_data_source_test.go` | Exchange client credentials for bearer token; requires `NETSKOPE_OAUTH2_CLIENT_ID` and `NETSKOPE_OAUTH2_CLIENT_SECRET` env vars (skipped if absent) |
+
 #### Added in v0.4.6
 
 | Test | File | Description |
@@ -468,7 +474,7 @@ All tests SKIPPED - valid event_types not documented by API.
 | netskope_ip_sec_po_ps_list | **NO** | Missing test file |
 | netskope_npa_private_app | Yes | private_app_id, name, hostname via AttrPair |
 | netskope_npa_private_apps_list | Yes | private_apps.#, private_app_id > 0 (BUG-012) |
-| netskope_npa_publisher | Yes | publisher_id, publisher_name via AttrPair |
+| netskope_npa_publisher | Yes | publisher_id, publisher_name via AttrPair; `TestAccNPAPublisher_withConnectedApp` exercises BUG-017 read path with connected apps |
 | netskope_npa_publishers_list | Yes | data.publishers.# is set |
 | netskope_npa_policy_groups | Yes | id, group_name via AttrPair |
 | netskope_npa_policy_groups_list | Yes | data.# is set |

--- a/docs/KNOWN_API_ISSUES.md
+++ b/docs/KNOWN_API_ISSUES.md
@@ -25,6 +25,8 @@ This document tracks known behavioral inconsistencies and quirks in the Netskope
   - [13. API Tokens Cannot Resolve User Notification Templates for Block Rules](#13-api-tokens-cannot-resolve-user-notification-templates-for-block-rules)
   - [14. `device_classification_id` Type Mismatch (String vs Integer)](#14-device_classification_id-type-mismatch-string-vs-integer)
   - [16. NPA Rules Ordering — Eventual Consistency](#16-npa-rules-ordering--eventual-consistency)
+- [Infrastructure API Issues (17)](#infrastructure-api-issues-17)
+  - [17. `connected_apps` Field Shape Differs Between List and Get-by-ID](#17-connected_apps-field-shape-differs-between-list-and-get-by-id)
 - [Terraform Provider Implications](#terraform-provider-implications)
 - [General Recommendations](#general-recommendations)
 
@@ -724,6 +726,33 @@ The provider then sleeps 2 seconds and verifies the live order matches the desir
 The SDK's default retry policy (exponential backoff, up to 5 minutes per call on 429 or 5XX responses) applies to each PATCH. Apply time may be longer if the API returns transient errors.
 
 **Status:** Known API limitation — no fix possible without an atomic reorder endpoint. Workaround implemented in `netskope_npa_rules_order` resource.
+
+---
+
+## Infrastructure API Issues (17)
+
+### 17. `connected_apps` Field Shape Differs Between List and Get-by-ID
+
+**Endpoints:** `GET /api/v2/infrastructure/publishers` vs `GET /api/v2/infrastructure/publishers/{id}`
+
+**Symptom:** `netskope_npa_publisher` ReadResource fails with `json: cannot unmarshal object into Go value of type string` for publishers that have at least one private app connected.
+
+**Details:** The two publisher endpoints return `connected_apps` in different shapes:
+
+- **List** (`GET /infrastructure/publishers`): array of strings
+  ```json
+  "connected_apps": ["[AppName]"]
+  ```
+- **Get-by-ID** (`GET /infrastructure/publishers/{id}`): array of objects
+  ```json
+  "connected_apps": [{"access_method": "client", "host": "...", "last_connected": null, "name": "[AppName]"}]
+  ```
+
+The SDK struct previously declared `ConnectedApps []string`, which matched the list endpoint but broke on the get-by-ID response for publishers with connected apps. Publishers with no connected apps returned `connected_apps: []` (empty array), which masked the bug in tests.
+
+**Workaround:** The `connected_apps` field is marked `x-speakeasy-ignore: true` in the OAS for the `publisher_response` (get-by-ID) schema. This removes the field from the SDK struct entirely — the JSON deserializer skips it, avoiding the type mismatch. The field was already excluded from Terraform state (`x-speakeasy-terraform-ignore`), so there is no change in Terraform behaviour.
+
+**Fixed in:** v0.4.7 — see [BUG-017](bugs/BUG-017-publisher-connected-apps-type-mismatch.md), GitHub issue #96.
 
 ---
 

--- a/docs/api-audit/npa-publishers.md
+++ b/docs/api-audit/npa-publishers.md
@@ -1,0 +1,154 @@
+# API Audit: NPA Publishers
+
+**Date:** 2026-07-07
+**Tenant:** bespin.goskope.com
+**Base path:** `/api/v2/infrastructure/publishers`
+
+## Endpoints Tested
+
+| Method | Path | Status | Notes |
+|--------|------|--------|-------|
+| GET | `/infrastructure/publishers` | 200 | Returns all publishers |
+| GET | `/infrastructure/publishers/{id}` | 200 | Returns single publisher by ID |
+
+---
+
+## `connected_apps` — Shape Differs Between List and Get-by-ID
+
+### What the Swagger says
+
+The OAS defines `connected_apps` as `array of strings` in both the list schema
+(`publishers_get_response`) and the get-by-ID schema (`publisher_response`):
+
+```yaml
+connected_apps:
+  type: array
+  items:
+    type: string
+  example:
+    - '[Cloud Exchange]'
+    - '[WebServer]'
+```
+
+### What the API actually returns
+
+**`GET /infrastructure/publishers`** — matches the Swagger: array of strings.
+
+```json
+{
+    "data": {
+        "publishers": [
+            {
+                "apps_count": 1,
+                "assessment": null,
+                "capabilities": null,
+                "common_name": "3418b5ec6ad1f703",
+                "connected_apps": [
+                    "[BD-Gartner-HPE]"
+                ],
+                "last_download_url": null,
+                "last_log_collection_status": null,
+                "last_log_collection_timestamp": null,
+                "last_log_s3_key": null,
+                "lbrokerconnect": false,
+                "log_collection_in_progress": false,
+                "publisher_id": 10950,
+                "publisher_name": "BD-gartner-hpe-sd-wan",
+                "publisher_upgrade_profiles_external_id": 1,
+                "registered": false,
+                "status": "not registered",
+                "stitcher_id": null,
+                "stitcher_pop": null,
+                "tags": [],
+                "upgrade_failed_reason": null,
+                "upgrade_request": false,
+                "upgrade_status": {
+                    "upstat": "not_support"
+                }
+            }
+        ]
+    },
+    "status": "success",
+    "total": 11
+}
+```
+
+**`GET /infrastructure/publishers/10950`** — does NOT match the Swagger: returns an
+array of objects, not strings.
+
+```json
+{
+    "data": {
+        "apps_count": 1,
+        "assessment": null,
+        "capabilities": null,
+        "common_name": "3418b5ec6ad1f703",
+        "connected_apps": [
+            {
+                "access_method": "client",
+                "host": "172.20.36.40",
+                "last_connected": null,
+                "name": "[BD-Gartner-HPE]"
+            }
+        ],
+        "id": 10950,
+        "labels": [],
+        "last_download_url": null,
+        "last_log_collection_status": null,
+        "last_log_collection_timestamp": null,
+        "last_log_s3_key": null,
+        "lbrokerconnect": false,
+        "log_collection_in_progress": false,
+        "name": "BD-gartner-hpe-sd-wan",
+        "publisher_upgrade_profiles_id": 1,
+        "registered": false,
+        "status": "not registered",
+        "stitcher_id": null,
+        "stitcher_pop": null,
+        "tags": [],
+        "upgrade_failed_reason": null,
+        "upgrade_request": false,
+        "upgrade_status": {
+            "upstat": "not_support"
+        }
+    },
+    "status": "success"
+}
+```
+
+### Summary of deviations
+
+| Field | Swagger (publisher_response) | GET /publishers (list) | GET /publishers/{id} |
+|-------|------------------------------|------------------------|----------------------|
+| `connected_apps` items | `string` | `string` ✓ | `object` ✗ |
+| `connected_apps[].access_method` | not defined | n/a | `string` |
+| `connected_apps[].host` | not defined | n/a | `string` |
+| `connected_apps[].last_connected` | not defined | n/a | `string\|null` |
+| `connected_apps[].name` | not defined | n/a | `string` |
+
+### Additional field name differences between list and get-by-ID
+
+The two endpoints also use different field names for the same values:
+
+| Concept | GET /publishers (list) | GET /publishers/{id} |
+|---------|------------------------|----------------------|
+| Publisher ID | `publisher_id` | `id` |
+| Publisher name | `publisher_name` | `name` |
+| Upgrade profile ID | `publisher_upgrade_profiles_external_id` | `publisher_upgrade_profiles_id` |
+| Labels | not present | `labels: []` |
+
+### Provider impact
+
+The Swagger deviation in `connected_apps` : the Go SDK struct
+declared `ConnectedApps []string`, which matched the list endpoint but panicked
+on the get-by-ID response for any publisher with connected apps:
+
+```
+json: cannot unmarshal object into Go value of type string
+```
+
+**Fix:** `connected_apps` is annotated `x-speakeasy-ignore: true` in
+`publisher_response` in the OAS. The field is dropped from the SDK struct
+entirely and the JSON decoder skips it. The field was already excluded from
+Terraform state (`x-speakeasy-terraform-ignore`), so there is no change in
+provider behaviour.

--- a/docs/bugs/BUG-017-publisher-connected-apps-type-mismatch.md
+++ b/docs/bugs/BUG-017-publisher-connected-apps-type-mismatch.md
@@ -1,0 +1,156 @@
+---
+title: BUG-017 — Publisher ReadResource fails due to connected_apps type mismatch
+status: Fixed
+github_issue: 96
+---
+
+## Summary
+
+`netskope_npa_publisher` ReadResource fails with:
+
+```
+error unmarshaling json response body: json: cannot unmarshal object into Go value of type string
+```
+
+This occurs during `terraform plan` or `terraform apply` for **existing publishers that have connected apps**.
+
+## Root Cause
+
+The `GET /api/v2/infrastructure/publishers/{id}` endpoint changed the shape of the `connected_apps` field. It now returns an **array of objects**:
+
+```json
+"connected_apps": [
+  {
+    "access_method": "client",
+    "host": "172.20.36.40",
+    "last_connected": null,
+    "name": "[BD-Gartner-HPE]"
+  }
+]
+```
+
+The SDK struct had `ConnectedApps []string` (array of strings), causing Go's JSON unmarshaler to fail when it tries to decode an object into a string element.
+
+**Note:** The bug only manifests for publishers with at least one connected app. Newly created test publishers with no apps return an empty `connected_apps` array, which explains why acceptance tests did not catch this.
+
+The issue reporter attributed the failure to `upgrade_status` — but `upgrade_status` was already correctly typed as an object in the SDK. The actual culprit was `connected_apps`.
+
+The list endpoint (`GET /infrastructure/publishers`) still returns `connected_apps` as an array of strings. Only the GET-by-ID endpoint changed shape.
+
+## Fix
+
+Changed the `connected_apps` field annotation in `publisher_response.data` from `x-speakeasy-terraform-ignore: true` to `x-speakeasy-ignore: true` in the OAS:
+
+```
+/Users/jharris/speakeasy/netskope-apiv2-oas/endpoints/infrastructure/npa_publishers.yaml
+```
+
+`x-speakeasy-ignore: true` removes the field entirely from the generated SDK struct, so the JSON deserializer skips it. Since the field was already hidden from Terraform state via `x-speakeasy-terraform-ignore`, this is a no-op from the user's perspective — publishers still work correctly, connected apps are just not surfaced in Terraform state (by design, pre-existing behaviour).
+
+Regenerated SDK via `speakeasy run`.
+
+## Files Changed
+
+- `netskope-apiv2-oas/endpoints/infrastructure/npa_publishers.yaml` — annotation change
+- `internal/sdk/models/shared/publisherresponse.go` — `ConnectedApps` field removed
+- `internal/provider/npapublisher_resource_sdk.go` — removed `ConnectedApps` mapping
+
+## Tests
+
+- `TestAccNPAPublisher_basic` — passes (was passing before; now covers publisher refresh without error)
+- New drift detection test added to verify no perpetual diff for publishers with connected apps
+
+## API Inconsistency
+
+The `GET /infrastructure/publishers` (list) and `GET /infrastructure/publishers/{id}` (get-by-ID) return different shapes for `connected_apps` for the same publisher. The following responses were captured from the bespin tenant against publisher `10950` (`BD-gartner-hpe-sd-wan`).
+
+### `GET /api/v2/infrastructure/publishers` (list)
+
+`connected_apps` is an **array of strings**:
+
+```json
+{
+    "data": {
+        "publishers": [
+            {
+                "apps_count": 1,
+                "assessment": null,
+                "capabilities": null,
+                "common_name": "3418b5ec6ad1f703",
+                "connected_apps": [
+                    "[BD-Gartner-HPE]"
+                ],
+                "last_download_url": null,
+                "last_log_collection_status": null,
+                "last_log_collection_timestamp": null,
+                "last_log_s3_key": null,
+                "lbrokerconnect": false,
+                "log_collection_in_progress": false,
+                "publisher_id": 10950,
+                "publisher_name": "BD-gartner-hpe-sd-wan",
+                "publisher_upgrade_profiles_external_id": 1,
+                "registered": false,
+                "status": "not registered",
+                "stitcher_id": null,
+                "stitcher_pop": null,
+                "tags": [],
+                "upgrade_failed_reason": null,
+                "upgrade_request": false,
+                "upgrade_status": {
+                    "upstat": "not_support"
+                }
+            }
+        ]
+    },
+    "status": "success",
+    "total": 11
+}
+```
+
+### `GET /api/v2/infrastructure/publishers/10950` (get-by-ID)
+
+`connected_apps` is an **array of objects**:
+
+```json
+{
+    "data": {
+        "apps_count": 1,
+        "assessment": null,
+        "capabilities": null,
+        "common_name": "3418b5ec6ad1f703",
+        "connected_apps": [
+            {
+                "access_method": "client",
+                "host": "172.20.36.40",
+                "last_connected": null,
+                "name": "[BD-Gartner-HPE]"
+            }
+        ],
+        "id": 10950,
+        "labels": [],
+        "last_download_url": null,
+        "last_log_collection_status": null,
+        "last_log_collection_timestamp": null,
+        "last_log_s3_key": null,
+        "lbrokerconnect": false,
+        "log_collection_in_progress": false,
+        "name": "BD-gartner-hpe-sd-wan",
+        "publisher_upgrade_profiles_id": 1,
+        "registered": false,
+        "status": "not registered",
+        "stitcher_id": null,
+        "stitcher_pop": null,
+        "tags": [],
+        "upgrade_failed_reason": null,
+        "upgrade_request": false,
+        "upgrade_status": {
+            "upstat": "not_support"
+        }
+    },
+    "status": "success"
+}
+```
+
+The list endpoint also omits fields present in the get-by-ID response (`id`, `labels`, `publisher_upgrade_profiles_id`) and uses different field names for the same values (`publisher_id` vs `id`, `publisher_name` vs `name`, `publisher_upgrade_profiles_external_id` vs `publisher_upgrade_profiles_id`).
+
+Logged in `docs/KNOWN_API_ISSUES.md`.

--- a/internal/provider/npapublisher_resource_test.go
+++ b/internal/provider/npapublisher_resource_test.go
@@ -141,6 +141,44 @@ func TestAccNPAPublisher_withUpgradeProfile(t *testing.T) {
 	})
 }
 
+// TestAccNPAPublisher_withConnectedApp verifies that publisher ReadResource
+// succeeds when the publisher has at least one private app connected to it.
+// Regression test for BUG-017: the GET-by-ID endpoint returns connected_apps
+// as an array of objects, not strings. Without the fix the Read fails with:
+//
+//	json: cannot unmarshal object into Go value of type string
+func TestAccNPAPublisher_withConnectedApp(t *testing.T) {
+	rName := fmt.Sprintf("%s-%s", testutil.ResourcePrefix, acctest.RandString(8))
+	resourceName := "netskope_npa_publisher.test"
+	vars := config.Variables{
+		"name": config.StringVariable(rName),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.PreCheck(t) },
+		ProtoV6ProviderFactories: testutil.ProtoV6ProviderFactories,
+		CheckDestroy:             testutil.CheckResourceDestroy("netskope_npa_publisher"),
+		Steps: []resource.TestStep{
+			{
+				// Create publisher + private app assigned to it.
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: vars,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutil.CheckResourceExists(resourceName, "publisher_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "publisher_id"),
+				),
+			},
+			{
+				// Re-read the publisher now that it has a connected app.
+				// This exercises the connected_apps object deserialization path.
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: vars,
+				PlanOnly:        true,
+			},
+		},
+	})
+}
+
 // TestAccNPAPublisher_disappears verifies the resource lifecycle works correctly.
 // Note: A true "disappears" test that deletes via API requires the provider's
 // Read function to properly handle "resource not found" responses and remove

--- a/internal/provider/testdata/TestAccNPAPublisher_withConnectedApp/main.tf
+++ b/internal/provider/testdata/TestAccNPAPublisher_withConnectedApp/main.tf
@@ -1,0 +1,33 @@
+variable "name" {
+  type = string
+}
+
+resource "netskope_npa_publisher" "test" {
+  publisher_name = var.name
+}
+
+# Assign a private app to the publisher so that the publisher's GET-by-ID
+# response includes a non-empty connected_apps array.
+# This exercises the path fixed in BUG-017: the API returns connected_apps
+# as an array of objects, not strings, and the SDK must not fail to deserialize it.
+resource "netskope_npa_private_app" "test" {
+  private_app_name     = var.name
+  private_app_hostname = "test-bug017.internal"
+
+  protocols = [
+    {
+      port     = "443"
+      protocol = "tcp"
+    }
+  ]
+
+  publishers = [
+    {
+      publisher_id   = tostring(netskope_npa_publisher.test.publisher_id)
+      publisher_name = netskope_npa_publisher.test.publisher_name
+    }
+  ]
+
+  use_publisher_dns       = false
+  trust_self_signed_certs = false
+}

--- a/internal/sdk/internal/hooks/hookPublisherDeleteGuard.go
+++ b/internal/sdk/internal/hooks/hookPublisherDeleteGuard.go
@@ -1,0 +1,122 @@
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// publisherDeleteGuardHook checks for connected apps before allowing a publisher
+// DELETE to proceed. The Netskope API rejects deletes for publishers with connected
+// apps but returns a generic error. This hook issues a GET before the DELETE and
+// returns a descriptive error listing the connected app names if any are present.
+//
+// If the pre-check GET fails for any reason the hook passes through and lets the
+// DELETE proceed — better to surface a raw API error than to silently block a
+// valid delete.
+//
+// Connected-apps shape note (BUG-017): the GET-by-ID endpoint returns
+// connected_apps as an array of objects; the list endpoint returns strings.
+// This hook handles both shapes via extractConnectedAppNames.
+type publisherDeleteGuardHook struct{}
+
+var _ beforeRequestHook = (*publisherDeleteGuardHook)(nil)
+
+func (h *publisherDeleteGuardHook) BeforeRequest(hookCtx BeforeRequestContext, req *http.Request) (*http.Request, error) {
+	if hookCtx.OperationID != "deleteNPAPublishers" {
+		return req, nil
+	}
+
+	client := hookCtx.SDKConfiguration.Client
+	if client == nil {
+		return req, nil
+	}
+
+	ctx := hookCtx.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// The DELETE URL already contains the publisher ID — issue a GET to the same path.
+	getReq, err := http.NewRequestWithContext(ctx, http.MethodGet, req.URL.String(), nil)
+	if err != nil {
+		return req, nil
+	}
+
+	// Copy auth headers from the outgoing DELETE request.
+	for _, hdr := range []string{"Netskope-Api-Token", "Authorization"} {
+		if val := req.Header.Get(hdr); val != "" {
+			getReq.Header.Set(hdr, val)
+		}
+	}
+
+	resp, err := client.Do(getReq)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return req, nil
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return req, nil
+	}
+
+	var payload struct {
+		Data struct {
+			Name          string            `json:"name"`
+			ConnectedApps []json.RawMessage `json:"connected_apps"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return req, nil
+	}
+
+	names := extractConnectedAppNames(payload.Data.ConnectedApps)
+	if len(names) == 0 {
+		return req, nil
+	}
+
+	publisherName := payload.Data.Name
+	if publisherName == "" {
+		parts := strings.Split(strings.TrimRight(req.URL.Path, "/"), "/")
+		publisherName = parts[len(parts)-1]
+	}
+
+	return nil, fmt.Errorf(
+		"cannot delete publisher %q: %d app(s) still connected:\n  - %s\nDetach or delete these apps before destroying the publisher",
+		publisherName,
+		len(names),
+		strings.Join(names, "\n  - "),
+	)
+}
+
+// extractConnectedAppNames pulls app name strings from connected_apps elements,
+// which may be JSON strings or JSON objects depending on the API endpoint (BUG-017).
+func extractConnectedAppNames(elems []json.RawMessage) []string {
+	names := make([]string, 0, len(elems))
+	for _, elem := range elems {
+		if len(elem) == 0 {
+			continue
+		}
+		switch elem[0] {
+		case '"':
+			// String form from list endpoint: "[AppName]"
+			var s string
+			if json.Unmarshal(elem, &s) == nil && s != "" {
+				names = append(names, s)
+			}
+		case '{':
+			// Object form from get-by-ID endpoint: {"name": "[AppName]", ...}
+			var obj struct {
+				Name string `json:"name"`
+			}
+			if json.Unmarshal(elem, &obj) == nil && obj.Name != "" {
+				names = append(names, obj.Name)
+			}
+		}
+	}
+	return names
+}

--- a/internal/sdk/internal/hooks/hookPublisherDeleteGuard_test.go
+++ b/internal/sdk/internal/hooks/hookPublisherDeleteGuard_test.go
@@ -1,0 +1,309 @@
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/netskopeoss/terraform-provider-netskope/internal/sdk/internal/config"
+)
+
+// fakeHTTPClient wraps a function as a config.HTTPClient for testing.
+type fakeHTTPClient func(*http.Request) (*http.Response, error)
+
+func (f fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// fakePublisherGetClient returns a client that responds with a publisher GET body
+// containing the given name and connected_apps value.
+func fakePublisherGetClient(t *testing.T, name string, connectedApps interface{}) config.HTTPClient {
+	t.Helper()
+	return fakeHTTPClient(func(req *http.Request) (*http.Response, error) {
+		body := map[string]interface{}{
+			"status": "success",
+			"data": map[string]interface{}{
+				"name":           name,
+				"connected_apps": connectedApps,
+			},
+		}
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("failed to marshal test response: %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(string(b))),
+			Header:     make(http.Header),
+		}, nil
+	})
+}
+
+// deletePublisherCtx builds a BeforeRequestContext for a publisher DELETE.
+func deletePublisherCtx(operationID string, client config.HTTPClient) BeforeRequestContext {
+	return BeforeRequestContext{
+		HookContext: HookContext{
+			OperationID: operationID,
+			Context:     context.Background(),
+			SDKConfiguration: config.SDKConfiguration{
+				Client: client,
+			},
+		},
+	}
+}
+
+// deletePublisherReq builds a DELETE request for a given publisher ID.
+func deletePublisherReq(t *testing.T, publisherID int) *http.Request {
+	t.Helper()
+	url := fmt.Sprintf("https://example.goskope.com/api/v2/infrastructure/publishers/%d", publisherID)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Netskope-Api-Token", "test-token")
+	return req
+}
+
+// ============================================================================
+// BeforeRequest tests
+// ============================================================================
+
+// TestPublisherDeleteGuard_NonMatchingOp verifies that non-delete operations
+// pass through without any HTTP check being performed.
+func TestPublisherDeleteGuard_NonMatchingOp(t *testing.T) {
+	hook := &publisherDeleteGuardHook{}
+	req := deletePublisherReq(t, 10950)
+
+	// Client would panic if called — proves it is never invoked.
+	panicClient := fakeHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		t.Fatal("GET should not be issued for non-delete operations")
+		return nil, nil
+	})
+	ctx := deletePublisherCtx("getNPAPublisherById", panicClient)
+
+	result, err := hook.BeforeRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result != req {
+		t.Error("expected original request to be returned unchanged")
+	}
+}
+
+// TestPublisherDeleteGuard_NoConnectedApps verifies that a publisher with an
+// empty connected_apps array passes through without error.
+func TestPublisherDeleteGuard_NoConnectedApps(t *testing.T) {
+	hook := &publisherDeleteGuardHook{}
+	req := deletePublisherReq(t, 10950)
+	ctx := deletePublisherCtx("deleteNPAPublishers", fakePublisherGetClient(t, "my-publisher", []interface{}{}))
+
+	result, err := hook.BeforeRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("expected no error for publisher with no apps, got %v", err)
+	}
+	if result == nil {
+		t.Error("expected original request to be returned")
+	}
+}
+
+// TestPublisherDeleteGuard_ConnectedAppsAsStrings verifies that the hook blocks
+// a delete and names the connected apps when connected_apps is an array of strings
+// (the format returned by the list endpoint).
+func TestPublisherDeleteGuard_ConnectedAppsAsStrings(t *testing.T) {
+	hook := &publisherDeleteGuardHook{}
+	req := deletePublisherReq(t, 10950)
+	ctx := deletePublisherCtx("deleteNPAPublishers", fakePublisherGetClient(t, "my-publisher", []interface{}{
+		"[AppA]", "[AppB]",
+	}))
+
+	_, err := hook.BeforeRequest(ctx, req)
+	if err == nil {
+		t.Fatal("expected error for publisher with connected apps (string form)")
+	}
+	for _, want := range []string{"my-publisher", "[AppA]", "[AppB]"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error to contain %q, got: %v", want, err)
+		}
+	}
+}
+
+// TestPublisherDeleteGuard_ConnectedAppsAsObjects verifies that the hook blocks
+// a delete and names the connected apps when connected_apps is an array of objects
+// (the format returned by the get-by-ID endpoint, introduced in BUG-017).
+func TestPublisherDeleteGuard_ConnectedAppsAsObjects(t *testing.T) {
+	hook := &publisherDeleteGuardHook{}
+	req := deletePublisherReq(t, 10950)
+	ctx := deletePublisherCtx("deleteNPAPublishers", fakePublisherGetClient(t, "my-publisher", []interface{}{
+		map[string]interface{}{"name": "[AppA]", "access_method": "client", "host": "172.20.36.40", "last_connected": nil},
+		map[string]interface{}{"name": "[AppB]", "access_method": "client", "host": "10.0.0.2", "last_connected": nil},
+	}))
+
+	_, err := hook.BeforeRequest(ctx, req)
+	if err == nil {
+		t.Fatal("expected error for publisher with connected apps (object form)")
+	}
+	for _, want := range []string{"my-publisher", "[AppA]", "[AppB]"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error to contain %q, got: %v", want, err)
+		}
+	}
+}
+
+// TestPublisherDeleteGuard_AppCountInError verifies that the error message
+// includes the correct count of connected apps.
+func TestPublisherDeleteGuard_AppCountInError(t *testing.T) {
+	hook := &publisherDeleteGuardHook{}
+	req := deletePublisherReq(t, 10950)
+	ctx := deletePublisherCtx("deleteNPAPublishers", fakePublisherGetClient(t, "my-publisher", []interface{}{
+		"[App1]", "[App2]", "[App3]",
+	}))
+
+	_, err := hook.BeforeRequest(ctx, req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "3 app(s)") {
+		t.Errorf("expected error to report 3 apps, got: %v", err)
+	}
+}
+
+// TestPublisherDeleteGuard_GetFails verifies that a network error on the
+// pre-check GET does not block the delete — the hook passes through.
+func TestPublisherDeleteGuard_GetFails(t *testing.T) {
+	hook := &publisherDeleteGuardHook{}
+	req := deletePublisherReq(t, 10950)
+	client := fakeHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("network error")
+	})
+	ctx := deletePublisherCtx("deleteNPAPublishers", client)
+
+	result, err := hook.BeforeRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("expected hook to pass through on GET failure, got %v", err)
+	}
+	if result == nil {
+		t.Error("expected original request to pass through")
+	}
+}
+
+// TestPublisherDeleteGuard_GetNon200 verifies that a non-200 from the pre-check
+// GET does not block the delete.
+func TestPublisherDeleteGuard_GetNon200(t *testing.T) {
+	hook := &publisherDeleteGuardHook{}
+	req := deletePublisherReq(t, 10950)
+	client := fakeHTTPClient(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader(`{"status":"not found"}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	ctx := deletePublisherCtx("deleteNPAPublishers", client)
+
+	result, err := hook.BeforeRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("expected hook to pass through on non-200, got %v", err)
+	}
+	if result == nil {
+		t.Error("expected original request to pass through")
+	}
+}
+
+// TestPublisherDeleteGuard_NilClient verifies that a nil HTTP client (e.g. in
+// unit tests that construct minimal SDK configs) does not panic.
+func TestPublisherDeleteGuard_NilClient(t *testing.T) {
+	hook := &publisherDeleteGuardHook{}
+	req := deletePublisherReq(t, 10950)
+	ctx := deletePublisherCtx("deleteNPAPublishers", nil)
+
+	result, err := hook.BeforeRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("expected no error with nil client, got %v", err)
+	}
+	if result == nil {
+		t.Error("expected original request to pass through")
+	}
+}
+
+// TestPublisherDeleteGuard_AuthHeaderCopied verifies that the Netskope-Api-Token
+// header from the DELETE request is forwarded to the pre-check GET.
+func TestPublisherDeleteGuard_AuthHeaderCopied(t *testing.T) {
+	hook := &publisherDeleteGuardHook{}
+	req := deletePublisherReq(t, 10950)
+	req.Header.Set("Netskope-Api-Token", "secret-token")
+
+	var capturedToken string
+	client := fakeHTTPClient(func(r *http.Request) (*http.Response, error) {
+		capturedToken = r.Header.Get("Netskope-Api-Token")
+		body := `{"status":"success","data":{"name":"pub","connected_apps":[]}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	ctx := deletePublisherCtx("deleteNPAPublishers", client)
+
+	_, _ = hook.BeforeRequest(ctx, req)
+	if capturedToken != "secret-token" {
+		t.Errorf("expected Netskope-Api-Token to be forwarded, got %q", capturedToken)
+	}
+}
+
+// ============================================================================
+// extractConnectedAppNames tests
+// ============================================================================
+
+func TestExtractConnectedAppNames_Strings(t *testing.T) {
+	elems := jsonRawMessages(t, []interface{}{"[AppA]", "[AppB]"})
+	names := extractConnectedAppNames(elems)
+	if len(names) != 2 || names[0] != "[AppA]" || names[1] != "[AppB]" {
+		t.Errorf("unexpected names: %v", names)
+	}
+}
+
+func TestExtractConnectedAppNames_Objects(t *testing.T) {
+	elems := jsonRawMessages(t, []interface{}{
+		map[string]interface{}{"name": "[AppA]", "access_method": "client"},
+		map[string]interface{}{"name": "[AppB]", "access_method": "client"},
+	})
+	names := extractConnectedAppNames(elems)
+	if len(names) != 2 || names[0] != "[AppA]" || names[1] != "[AppB]" {
+		t.Errorf("unexpected names: %v", names)
+	}
+}
+
+func TestExtractConnectedAppNames_Empty(t *testing.T) {
+	names := extractConnectedAppNames(nil)
+	if len(names) != 0 {
+		t.Errorf("expected empty slice, got %v", names)
+	}
+}
+
+func TestExtractConnectedAppNames_ObjectMissingName(t *testing.T) {
+	elems := jsonRawMessages(t, []interface{}{
+		map[string]interface{}{"access_method": "client"}, // no name field
+	})
+	names := extractConnectedAppNames(elems)
+	if len(names) != 0 {
+		t.Errorf("expected no names from object without name field, got %v", names)
+	}
+}
+
+// jsonRawMessages marshals a slice of values into []json.RawMessage for testing.
+func jsonRawMessages(t *testing.T, vals []interface{}) []json.RawMessage {
+	t.Helper()
+	out := make([]json.RawMessage, len(vals))
+	for i, v := range vals {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("failed to marshal test value: %v", err)
+		}
+		out[i] = json.RawMessage(b)
+	}
+	return out
+}

--- a/internal/sdk/internal/hooks/registration.go
+++ b/internal/sdk/internal/hooks/registration.go
@@ -80,4 +80,9 @@ func initHooks(h *Hooks) {
 	// AIG token - remove expire_in when not configured (zero values rejected by API)
 	aigToken := &aigTokenRequestHook{}
 	h.registerBeforeRequestHook(aigToken)
+
+	// Publisher delete guard - blocks delete if connected apps are present and
+	// returns a descriptive error listing the app names (see BUG-017)
+	publisherDeleteGuard := &publisherDeleteGuardHook{}
+	h.registerBeforeRequestHook(publisherDeleteGuard)
 }

--- a/internal/sdk/models/shared/publisherresponse.go
+++ b/internal/sdk/models/shared/publisherresponse.go
@@ -254,7 +254,6 @@ type PublisherResponseData struct {
 	Assessment                 *PublisherResponseAssessment   `json:"assessment,omitempty"`
 	Capabilities               *PublisherResponseCapabilities `json:"capabilities,omitempty"`
 	CommonName                 *string                        `json:"common_name,omitempty"`
-	ConnectedApps              []string                       `json:"connected_apps,omitempty"`
 	PublisherID                *int                           `json:"id,omitempty"`
 	Labels                     []PublisherResponseLabels      `json:"labels,omitempty"`
 	Lbrokerconnect             *bool                          `json:"lbrokerconnect,omitempty"`
@@ -298,13 +297,6 @@ func (p *PublisherResponseData) GetCommonName() *string {
 		return nil
 	}
 	return p.CommonName
-}
-
-func (p *PublisherResponseData) GetConnectedApps() []string {
-	if p == nil {
-		return nil
-	}
-	return p.ConnectedApps
 }
 
 func (p *PublisherResponseData) GetPublisherID() *int {

--- a/internal/sdk/models/shared/publisherresponse_test.go
+++ b/internal/sdk/models/shared/publisherresponse_test.go
@@ -1,0 +1,122 @@
+package shared
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestPublisherResponseData_ConnectedAppsAsStrings verifies that a GET-by-ID
+// response where connected_apps is an array of strings (the documented API shape,
+// and the shape the list endpoint always returns) unmarshals without error and
+// that other fields are correctly populated.
+//
+// Regression test for GitHub issue #96 / BUG-017.
+func TestPublisherResponseData_ConnectedAppsAsStrings(t *testing.T) {
+	raw := `{
+		"apps_count": 1,
+		"common_name": "3418b5ec6ad1f703",
+		"connected_apps": ["[BD-Gartner-HPE]"],
+		"id": 10950,
+		"lbrokerconnect": false,
+		"name": "BD-gartner-hpe-sd-wan",
+		"publisher_upgrade_profiles_id": 1,
+		"registered": false,
+		"status": "not registered",
+		"upgrade_request": false,
+		"upgrade_status": {"upstat": "not_support"}
+	}`
+
+	var data PublisherResponseData
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		t.Fatalf("unmarshal failed with connected_apps as strings: %v", err)
+	}
+
+	assertPublisherFields(t, &data)
+}
+
+// TestPublisherResponseData_ConnectedAppsAsObjects verifies that a GET-by-ID
+// response where connected_apps is an array of objects (the shape currently
+// returned by the Netskope API, which differs from the documented string shape)
+// unmarshals without error and that other fields are correctly populated.
+//
+// This is the shape that caused the original crash:
+//
+//	json: cannot unmarshal object into Go value of type string
+//
+// Regression test for GitHub issue #96 / BUG-017.
+func TestPublisherResponseData_ConnectedAppsAsObjects(t *testing.T) {
+	raw := `{
+		"apps_count": 1,
+		"common_name": "3418b5ec6ad1f703",
+		"connected_apps": [
+			{
+				"access_method": "client",
+				"host": "172.20.36.40",
+				"last_connected": null,
+				"name": "[BD-Gartner-HPE]"
+			}
+		],
+		"id": 10950,
+		"lbrokerconnect": false,
+		"name": "BD-gartner-hpe-sd-wan",
+		"publisher_upgrade_profiles_id": 1,
+		"registered": false,
+		"status": "not registered",
+		"upgrade_request": false,
+		"upgrade_status": {"upstat": "not_support"}
+	}`
+
+	var data PublisherResponseData
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		t.Fatalf("unmarshal failed with connected_apps as objects: %v\n\nThis is the crash from GitHub issue #96. The connected_apps field must be excluded from the SDK struct (x-speakeasy-ignore: true) so the JSON decoder skips it regardless of shape.", err)
+	}
+
+	assertPublisherFields(t, &data)
+}
+
+// TestPublisherResponseData_NoConnectedApps verifies that a publisher with no
+// connected apps (empty array) unmarshals correctly. This is the case that
+// masked BUG-017 in testing — newly created publishers have no apps connected
+// so the type mismatch was never exercised.
+func TestPublisherResponseData_NoConnectedApps(t *testing.T) {
+	raw := `{
+		"apps_count": 0,
+		"common_name": "3418b5ec6ad1f703",
+		"connected_apps": [],
+		"id": 10950,
+		"lbrokerconnect": false,
+		"name": "BD-gartner-hpe-sd-wan",
+		"publisher_upgrade_profiles_id": 1,
+		"registered": false,
+		"status": "not registered",
+		"upgrade_request": false,
+		"upgrade_status": {"upstat": "not_support"}
+	}`
+
+	var data PublisherResponseData
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		t.Fatalf("unmarshal failed with empty connected_apps: %v", err)
+	}
+
+	assertPublisherFields(t, &data)
+}
+
+// assertPublisherFields verifies that fields unrelated to connected_apps are
+// correctly populated after unmarshaling, ensuring the fix does not regress
+// parsing of other fields.
+func assertPublisherFields(t *testing.T, data *PublisherResponseData) {
+	t.Helper()
+
+	if data.PublisherID == nil || *data.PublisherID != 10950 {
+		t.Errorf("expected publisher_id=10950, got %v", data.PublisherID)
+	}
+	if data.PublisherName == nil || *data.PublisherName != "BD-gartner-hpe-sd-wan" {
+		t.Errorf("expected name=%q, got %v", "BD-gartner-hpe-sd-wan", data.PublisherName)
+	}
+	if data.CommonName == nil || *data.CommonName != "3418b5ec6ad1f703" {
+		t.Errorf("expected common_name=%q, got %v", "3418b5ec6ad1f703", data.CommonName)
+	}
+	if data.UpgradeStatus == nil || data.UpgradeStatus.Upstat == nil || *data.UpgradeStatus.Upstat != "not_support" {
+		t.Errorf("expected upgrade_status.upstat=%q, got %v", "not_support", data.UpgradeStatus)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes a crash affecting all users on v0.3.3+ who have publishers with at least one connected private app. On every `terraform plan` or `terraform apply`, the provider calls `GET /infrastructure/publishers/{id}`, which now returns `connected_apps` as an array of objects. The SDK struct declared `[]string`, causing `json: cannot unmarshal object into Go value of type string`.
- Removes `ConnectedApps []string` from `PublisherResponseData` via `x-speakeasy-ignore` so the JSON decoder skips the field regardless of its shape (string array or object array). The field was already excluded from Terraform state so there is no user-visible change.
- Adds a pre-delete guard hook that issues a `GET` before any publisher `DELETE` and returns a descriptive error listing connected app names if any are present, since the API rejects deletes for publishers with connected apps.
- Documents the `connected_apps` shape inconsistency between the list and get-by-ID endpoints in `KNOWN_API_ISSUES.md` (issue #17) and `docs/api-audit/npa-publishers.md` with real API responses.

## Test plan

- [x] `go build ./...` — clean
- [x] `TestPublisherResponseData_ConnectedAppsAsStrings` — PASS (string shape, documents why bug was masked)
- [x] `TestPublisherResponseData_ConnectedAppsAsObjects` — PASS (object shape, reproduces original crash if fix is reverted)
- [x] `TestPublisherResponseData_NoConnectedApps` — PASS (empty array)
- [x] `TestPublisherDeleteGuard_*` (9 tests) — all PASS
- [x] `TestExtractConnectedAppNames_*` (4 tests) — all PASS
- [x] Full acceptance test suite — all PASS (638s, 0 failures)
- [x] `TestAccNPAPublisher_withConnectedApp` — exercises read path for publisher with connected app (regression guard)

## Notes

- Affects all releases from v0.3.3 onwards — noted in CHANGELOG
- The `connected_apps` field shape may revert to strings in a future API update; the fix handles both shapes
- The list data source (`netskope_npa_publishers_list`) is unaffected — it uses the list endpoint which has always returned strings