### PR TITLE
Prepare release v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [0.4.7] - Unreleased
+## [0.4.7] - 2026-07-08
 
 ### Fixed
 - **`netskope_npa_publisher` ReadResource crash for publishers with connected apps** ([BUG-017](docs/bugs/BUG-017-publisher-connected-apps-type-mismatch.md), [#96](https://github.com/netskopeoss/terraform-provider-netskope/issues/96)) — The `GET /infrastructure/publishers/{id}` endpoint changed `connected_apps` from an array of strings to an array of objects. The SDK struct still declared `[]string`, causing `json: cannot unmarshal object into Go value of type string` on every state refresh for publishers with at least one app connected. Fixed by excluding the field from SDK deserialization (`x-speakeasy-ignore`); it was already excluded from Terraform state. **Affects all releases from v0.3.3 onwards** — upgrade to v0.4.7 to resolve.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     netskope = {
       source  = "netskopeoss/netskope"
-      version = "0.4.6"
+      version = "0.4.7"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     netskope = {
       source  = "netskopeoss/netskope"
-      version = "0.4.6"
+      version = "0.4.7"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md `[0.4.7]` date from Unreleased to 2026-07-08
- Bump version to `0.4.7` in `examples/provider/provider.tf` and `docs/index.md`